### PR TITLE
fix: let kitex client use long conns

### DIFF
--- a/kitex/client/kitex_client.go
+++ b/kitex/client/kitex_client.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/cloudwego/kitex/client"
+	"github.com/cloudwego/kitex/pkg/connpool"
 	"github.com/gogo/protobuf/proto"
 	benchmark "github.com/rpcxio/rpcx-benchmark"
 	"github.com/rpcxio/rpcx-benchmark/kitex/pb"
@@ -65,7 +66,9 @@ func main() {
 	var clientIndex uint64
 	poolClients := make([]hello.Client, 0, *pool)
 	for i := 0; i < *pool; i++ {
-		c := hello.MustNewClient("echo", client.WithHostPorts(servers...))
+		c := hello.MustNewClient("echo",
+			client.WithHostPorts(servers...),
+			client.WithLongConnection(connpool.IdleConfig{MaxIdlePerAddress: 100, MaxIdleGlobal: 1000, MaxIdleTimeout: time.Minute}))
 		// warmup
 		for j := 0; j < 5; j++ {
 			c.Say(context.Background(), args)


### PR DESCRIPTION
hi，你好，感谢 rpcx-benchmark 项目增加了 kitex 的 benchmark。

但是由于 kitex client 默认使用短连接模式，而其他仓库均默认使用长连接，因此对比不太合理。

我们建议为 kitex client 配置长连接来参加对比，感谢！