### PR TITLE
feat: use mux conn pool for kitex client

### DIFF
--- a/kitex/client/kitex_client.go
+++ b/kitex/client/kitex_client.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/cloudwego/kitex/client"
-	"github.com/cloudwego/kitex/pkg/connpool"
 	"github.com/gogo/protobuf/proto"
 	"github.com/rpcxio/rpcx-benchmark/kitex/pb"
 	"github.com/rpcxio/rpcx-benchmark/kitex/pb/hello"
@@ -62,10 +61,11 @@ func main() {
 	// 每个goroutine的耗时记录
 	d := make([][]int64, n, n)
 
-	// kitex client本身就是pool对象，所以不再单独创建pool
+	// kitex client 使用内置多路复用连接池
 	client := hello.MustNewClient("echo",
 		client.WithHostPorts(servers...),
-		client.WithLongConnection(connpool.IdleConfig{MaxIdlePerAddress: *pool, MaxIdleGlobal: *pool, MaxIdleTimeout: time.Minute}))
+		client.WithMuxConnection(*pool),
+	)
 	// warmup
 	for j := 0; j < 5; j++ {
 		client.Say(context.Background(), args)

--- a/kitex/client/kitex_client.go
+++ b/kitex/client/kitex_client.go
@@ -67,9 +67,17 @@ func main() {
 		client.WithMuxConnection(*pool),
 	)
 	// warmup
-	for j := 0; j < 5; j++ {
-		client.Say(context.Background(), args)
+	var warmWg sync.WaitGroup
+	for i := 0; i < *pool; i++ {
+		warmWg.Add(1)
+		go func() {
+			defer warmWg.Done()
+			for j := 0; j < 5; j++ {
+				client.Say(context.Background(), args)
+			}
+		}()
 	}
+	warmWg.Wait()
 
 	// 栅栏，控制客户端同时开始测试
 	var startWg sync.WaitGroup

--- a/kitex/go.sum
+++ b/kitex/go.sum
@@ -23,8 +23,6 @@ github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYU
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apache/thrift v0.13.0 h1:5hryIiq9gtn+MiLVn0wP37kb/uTeRZgN08WoCsAhIhI=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
-github.com/apache/thrift v0.14.0 h1:vqZ2DP42i8th2OsgCcYZkirtbzvpZEFx53LiWDJXIAs=
-github.com/apache/thrift v0.14.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-metrics v0.3.6/go.mod h1:4O98XIr/9W0sxpJ8UaYkvjk10Iff7SnFrb4QAOwNTFc=
@@ -37,7 +35,6 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=
 github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
 github.com/bytedance/gopkg v0.0.0-20210705062217-74c74ebadcae/go.mod h1:birsdqRCbwnckJbdAvcSao+AzOyibVEoWB55MjpYpB8=
-github.com/bytedance/gopkg v0.0.0-20210709064845-3c00f9323f09 h1:may9mVMiCleawJOYHx6chSbpwrLwLOXO4cxHt7ehd5E=
 github.com/bytedance/gopkg v0.0.0-20210709064845-3c00f9323f09/go.mod h1:birsdqRCbwnckJbdAvcSao+AzOyibVEoWB55MjpYpB8=
 github.com/bytedance/gopkg v0.0.0-20210716082555-acbf5a2aa7e2 h1:1UZmQ8FuCgONuj8DNxMv3ITUVg8fA8yvzoKr9RhA008=
 github.com/bytedance/gopkg v0.0.0-20210716082555-acbf5a2aa7e2/go.mod h1:birsdqRCbwnckJbdAvcSao+AzOyibVEoWB55MjpYpB8=
@@ -51,18 +48,13 @@ github.com/cheekybits/genny v1.0.0/go.mod h1:+tQajlRqAUrPI7DOSpB0XAqZYtQakVtB7wX
 github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6Dob7S7YxXgwXpfOuvO54S+tGdZdw9fuRZt25Ag=
 github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp5jckzBHf4XRpQvBOLI+I=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cloudwego/kitex v0.0.2-0.20210722063233-67262666003d h1:ZLz3KeQ9uUGEA7vDjeeukzvVgpEjAvhJx/EgM/3iW/g=
-github.com/cloudwego/kitex v0.0.2-0.20210722063233-67262666003d/go.mod h1:NTTu8szFfMKY9pxa7JmI/4FZpD15p5YUHLTYMqsXj9o=
 github.com/cloudwego/kitex v0.0.3 h1:bZN8rxh5uArwFbO2W5jx6Ie7l53/gzS4b22roNjnMgY=
 github.com/cloudwego/kitex v0.0.3/go.mod h1:NfZ3Zj8MA+DklZd+z8i6/PEFmrnJAtHrz3AofZAKhKE=
-github.com/cloudwego/netpoll v0.0.2 h1:YIFcR1aN59/nof3KGqOnfjNWCiWr98xfD19J3QYpCPU=
 github.com/cloudwego/netpoll v0.0.2/go.mod h1:rZOiNI0FYjuvNybXKKhAPUja03loJi/cdv2F55AE6E8=
 github.com/cloudwego/netpoll v0.0.3 h1:LemwD6LQDhy3GNz/evTyh7DlxGnBua0Jl+5KmeVHXxA=
 github.com/cloudwego/netpoll v0.0.3/go.mod h1:rZOiNI0FYjuvNybXKKhAPUja03loJi/cdv2F55AE6E8=
 github.com/cloudwego/netpoll-http2 v0.0.4 h1:pN4uqjklPdvuALd3nFH5UFlmxB7vy7t8MkvKaV8HavU=
 github.com/cloudwego/netpoll-http2 v0.0.4/go.mod h1:iFr5SzJCXIYgBg0ubL0fZiCQ6W36s9p0KjXpV04lmoY=
-github.com/cloudwego/thriftgo v0.0.1 h1:anQDkYKoQVV14a451KBRX4YELXa5hUUUOtTFf0SW72c=
-github.com/cloudwego/thriftgo v0.0.1/go.mod h1:LzeafuLSiHA9JTiWC8TIMIq64iadeObgRUhmVG1OC/w=
 github.com/cloudwego/thriftgo v0.0.2-0.20210726073420-0145861fcd04 h1:xrb9zM079RW/DgxuOWF9/MdD0b3sM1W76BN7SxJW+vo=
 github.com/cloudwego/thriftgo v0.0.2-0.20210726073420-0145861fcd04/go.mod h1:LzeafuLSiHA9JTiWC8TIMIq64iadeObgRUhmVG1OC/w=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
@@ -103,7 +95,6 @@ github.com/go-ping/ping v0.0.0-20201115131931-3300c582a663/go.mod h1:35JbSyV/BYq
 github.com/go-redis/redis/v8 v8.8.2/go.mod h1:F7resOH5Kdug49Otu24RjHWwgK7u9AmtqWMnCV1iP5Y=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
-github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
@@ -128,7 +119,6 @@ github.com/golang/protobuf v1.4.1/go.mod h1:U8fpvMrcmy5pZrNK1lt4xCsGvpyWQ/VVv6QD
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
-github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.2/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
@@ -289,8 +279,6 @@ github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+Gx
 github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rpcxio/libkv v0.5.1-0.20210420120011-1fceaedca8a5/go.mod h1:zHGgtLr3cFhGtbalum0BrMPOjhFZFJXCKiws/25ewls=
-github.com/rpcxio/rpcx-benchmark/stat v0.0.0-20210725144741-82e06e86a2a9 h1:sn//i92U/j+kEU4hITAjJP2iJaXqr9B0xXlNWsmnM68=
-github.com/rpcxio/rpcx-benchmark/stat v0.0.0-20210725144741-82e06e86a2a9/go.mod h1:32f+9tSH8bNuevDaa5azuQlB1PBf6hMEi1XKlf/+qxc=
 github.com/rpcxio/rpcx-benchmark/stat v0.0.0-20210725150441-a81c6568c195 h1:xd/WwOHsZFpkY8YdHZJklQ04rfnGVLx7HrptLdEChHA=
 github.com/rpcxio/rpcx-benchmark/stat v0.0.0-20210725150441-a81c6568c195/go.mod h1:32f+9tSH8bNuevDaa5azuQlB1PBf6hMEi1XKlf/+qxc=
 github.com/rs/cors v1.7.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
@@ -326,7 +314,6 @@ github.com/shurcooL/webdavfs v0.0.0-20170829043945-18c3829fa133/go.mod h1:hKmq5k
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/smallnest/quick v0.0.0-20200505103731-c8c83f9c76d3/go.mod h1:pCMr9YKzcruQNKA1483At0JJkkB2oTiw1wSXCcXgDCI=
-github.com/smallnest/rpcx v1.6.4 h1:2ayiU7C93MqddgCBrw7P7g2RxFi/MoyFXFpAZPQOvcc=
 github.com/smallnest/rpcx v1.6.4/go.mod h1:d1qxk7MoRETCA2fteORZUToX5PTz9NoNWiKPqMD0OaI=
 github.com/smallnest/rpcx v1.6.5 h1:Bsbt+etymkbSAAWjfB9z7ZduKgnwbWJi238l8hySe50=
 github.com/smallnest/rpcx v1.6.5/go.mod h1:KL4sAwUz0sGPK9DSmB1oIqPhhq8Zze4NTgSYkBkjHZ0=
@@ -425,7 +412,6 @@ golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4/go.mod h1:RBQZq4jEuRlivfhVLdyRGr576XBO4/greRjx4P4O3yc=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
-golang.org/x/net v0.0.0-20210614182718-04defd469f4e h1:XpT3nA5TvE525Ne3hInMh6+GETgn27Zfm9dxsThnX2Q=
 golang.org/x/net v0.0.0-20210614182718-04defd469f4e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210726213435-c6fcb2dbf985 h1:4CSI6oo7cOjJKajidEljs9h+uP0rRZBPPPhcCbj5mw8=
 golang.org/x/net v0.0.0-20210726213435-c6fcb2dbf985/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
@@ -533,7 +519,6 @@ google.golang.org/genproto v0.0.0-20190425155659-357c62f0e4bb/go.mod h1:VzzqZJRn
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/genproto v0.0.0-20200513103714-09dca8ec2884/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
-google.golang.org/genproto v0.0.0-20210513213006-bf773b8c8384 h1:z+j74wi4yV+P7EtK9gPLGukOk7mFOy9wMQaC0wNb7eY=
 google.golang.org/genproto v0.0.0-20210513213006-bf773b8c8384/go.mod h1:P3QM42oQyzQSnHPnZ/vqoCdDmzH28fzWByN9asMeM8A=
 google.golang.org/genproto v0.0.0-20210729151513-df9385d47c1b h1:4xoALQmXxqVdDdLimpPyPeDdsJzo+nFTJw9euAMpqgM=
 google.golang.org/genproto v0.0.0-20210729151513-df9385d47c1b/go.mod h1:ob2IJxKrgPT52GcgX759i1sleT07tiKowYBGbczaW48=
@@ -560,7 +545,6 @@ google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2
 google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
-google.golang.org/protobuf v1.26.0 h1:bxAC2xTBsZGibn2RTntX0oH50xLsqy1OxA9tTL3p/lk=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.27.1 h1:SnqbnDw1V7RiZcXPx5MEeqPv2s79L9i7BJUlG/+RurQ=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=

--- a/kitex/server/kitex_server.go
+++ b/kitex/server/kitex_server.go
@@ -40,7 +40,11 @@ func main() {
 	ipAddr, portNum, _ := net.SplitHostPort(*host)
 	ip := net.ParseIP(ipAddr)
 	port, _ := strconv.Atoi(portNum)
-	svr := hello.NewServer(new(Hello), server.WithServiceAddr(&net.TCPAddr{IP: ip, Port: port}))
+	svr := hello.NewServer(
+		new(Hello),
+		server.WithServiceAddr(&net.TCPAddr{IP: ip, Port: port}),
+		server.WithMuxTransport(), // 开启多路复用
+	)
 	if err := svr.Run(); err != nil {
 		log.Fatalf("server stopped with error:", err)
 	} else {


### PR DESCRIPTION
Hi, 感谢提供该压测项目的对比。我注意到当前 rpcx ，grpc 使用的都是连接多路复用，而 kitex 使用的是长连接池。并且连接池大小限定在了并发数上。

这里存在一个问题是，kitex 的长连接池并不开启多路复用，所以 sizeof(longconnpool) 与 sizeof(muxconnpool) 之间强行对齐从连接模型上来说是不合理的。

这个 PR 主要是把 kitex 改成了多路复用的模式，对齐其他 client 的连接模型。另外，预热也需要并发预热，否则只会预热到当个连接上。